### PR TITLE
Change production database name

### DIFF
--- a/api/config/config.json
+++ b/api/config/config.json
@@ -17,7 +17,7 @@
     "username": "quran_dev",
     "password": "dev_quran",
     "database": "audio_quran",
-    "host": "postgres",
+    "host": "db.quranicaudio.com",
     "dialect": "postgres"
   }
 }


### PR DESCRIPTION
This will make it easier to link multiple containers against the same database.