### PR TITLE
Fixed style bugs

### DIFF
--- a/src/components/Audioplayer/mobile.scss
+++ b/src/components/Audioplayer/mobile.scss
@@ -45,7 +45,6 @@ $brand-color: $brand-primary;
         position: relative;
         margin-bottom: 0;
         z-index: 1;
-        left: 15px;
         top: -4px;
     }
 

--- a/src/containers/Qari/style.scss
+++ b/src/containers/Qari/style.scss
@@ -7,8 +7,6 @@
   color: #ffffff;
   padding-bottom: 5rem;
   background-color: $brand-primary;
-  margin-left: -15px;
-  margin-right: -15px;
   margin-bottom: 20px;
   @include mobile() {
       min-height: 350px;


### PR DESCRIPTION
Removed horizontal scrolling in desktop view of recitation page (fixes #90) and fixed alignment of reciter name in mobile view.

Horizontal scrolling before:
<img width="1280" alt="screen shot 2017-10-24 at 1 31 53 am" src="https://user-images.githubusercontent.com/9062287/31933055-e00c6d48-b85c-11e7-9d93-31183632a243.png">
After:
<img width="1280" alt="screen shot 2017-10-24 at 1 32 42 am" src="https://user-images.githubusercontent.com/9062287/31933075-ea471e02-b85c-11e7-9e38-783f84f859cc.png">

Reciter name alignment before:
<img width="347" alt="screen shot 2017-10-24 at 1 30 37 am" src="https://user-images.githubusercontent.com/9062287/31933110-fed6d416-b85c-11e7-96b3-b8c50f243851.png">
After:
<img width="347" alt="screen shot 2017-10-24 at 1 30 54 am" src="https://user-images.githubusercontent.com/9062287/31933119-0aa8c38a-b85d-11e7-9fd8-483dadaf727c.png">

