### PR TITLE
Allow play/pause/next/previous keyboard control and fix mobile audio player next/previous button disabling

### DIFF
--- a/src/components/Audioplayer/CommonAudio.js
+++ b/src/components/Audioplayer/CommonAudio.js
@@ -81,4 +81,41 @@ export default class CommonAudio {
       file.onended = null;
     }
   }
+
+  static isPlayPreviousDisabled() {
+    const { surah, surahPage, qari } = this.props; // eslint-disable-line no-shadow
+    const disableBasedOnSurah = surah ? surah.id === 1 && true : true;
+    const disabled = surahPage ? qari.id === 1 && true : disableBasedOnSurah;
+    return disabled;
+  }
+
+  static isPlayNextDisabled() {
+    const { surah, qaris, surahPage, qari } = this.props; // eslint-disable-line no-shadow
+    const disableBasedOnSurah = surah ? surah.id === 114 && true : true;
+    const disabled = surahPage
+      ? qari.id === Object.keys(qaris).length
+      : disableBasedOnSurah;
+    return disabled;
+  }
+
+  static handleKeyboardEvent(event) {
+    const { code } = event;
+    const { previous, next, playPause, surahs } = this.props; // eslint-disable-line no-shadow
+    if (code === 'Space') {
+      event.preventDefault();
+      playPause();
+    } else if (
+      (code === 'ArrowRight' || code === 'ArrowDown') &&
+      !this.isPlayNextDisabled()
+    ) {
+      event.preventDefault();
+      next({ surahs: Object.values(surahs) });
+    } else if (
+      (code === 'ArrowLeft' || code === 'ArrowUp') &&
+      !this.isPlayPreviousDisabled()
+    ) {
+      event.preventDefault();
+      previous({ surahs: Object.values(surahs) });
+    }
+  }
 }

--- a/src/components/Audioplayer/MobilePlayer.js
+++ b/src/components/Audioplayer/MobilePlayer.js
@@ -57,7 +57,9 @@ class MobilePlayer extends Component {
     this.handleRemoveFileListeneres = Common.handleRemoveFileListeneres.bind(
       this
     );
-    this.handleKeyboardEvent = this.handleKeyboardEvent.bind(this);
+    this.isPlayPreviousDisabled = Common.isPlayPreviousDisabled.bind(this);
+    this.isPlayNextDisabled = Common.isPlayNextDisabled.bind(this);
+    this.handleKeyboardEvent = Common.handleKeyboardEvent.bind(this);
 
     this.state = {
       open: true
@@ -83,44 +85,6 @@ class MobilePlayer extends Component {
 
   componentWillUnmount() {
     document.removeEventListener('keydown', this.handleKeyboardEvent);
-  }
-
-  isPlayPreviousDisabled() {
-    const { surah, surahPage, qari } = this.props; // eslint-disable-line no-shadow
-    const disableBasedOnSurah = surah ? surah.id === 1 && true : true;
-    const disabled = surahPage ? qari.id === 1 && true : disableBasedOnSurah;
-    return disabled;
-  }
-
-  isPlayNextDisabled() {
-    const { surah, qaris, surahPage, qari } = this.props; // eslint-disable-line no-shadow
-    const disableBasedOnSurah = surah ? surah.id === 114 && true : true;
-    const disabled = surahPage
-      ? qari.id === Object.keys(qaris).length
-      : disableBasedOnSurah;
-    console.log(surah, surahPage, disableBasedOnSurah, disabled);
-    return disabled;
-  }
-
-  handleKeyboardEvent(event) {
-    const { code } = event;
-    const { previous, next, playPause, surahs } = this.props; // eslint-disable-line no-shadow
-    if (code === 'Space') {
-      event.preventDefault();
-      playPause();
-    } else if (
-      (code === 'ArrowRight' || code === 'ArrowDown') &&
-      !this.isPlayNextDisabled()
-    ) {
-      event.preventDefault();
-      next({ surahs: Object.values(surahs) });
-    } else if (
-      (code === 'ArrowLeft' || code === 'ArrowUp') &&
-      !this.isPlayPreviousDisabled()
-    ) {
-      event.preventDefault();
-      previous({ surahs: Object.values(surahs) });
-    }
   }
 
   renderPlayStopButtons() {

--- a/src/components/Audioplayer/MobilePlayer.js
+++ b/src/components/Audioplayer/MobilePlayer.js
@@ -57,21 +57,69 @@ class MobilePlayer extends Component {
     this.handleRemoveFileListeneres = Common.handleRemoveFileListeneres.bind(
       this
     );
+    this.handleKeyboardEvent = this.handleKeyboardEvent.bind(this);
 
     this.state = {
       open: true
     };
   }
 
+  componentDidMount() {
+    document.addEventListener('keydown', this.handleKeyboardEvent);
+  }
+
   componentWillReceiveProps(nextProps) {
     if (
-      this.props.surah !== nextProps.surah || this.props.qari !== nextProps.qari
+      this.props.surah !== nextProps.surah ||
+      this.props.qari !== nextProps.qari
     ) {
       this.handleFileLoad(nextProps.file);
       this.handleRemoveFileListeneres(this.props.file);
       this.setState({
         open: true
       });
+    }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.handleKeyboardEvent);
+  }
+
+  isPlayPreviousDisabled() {
+    const { surah, surahPage, qari } = this.props; // eslint-disable-line no-shadow
+    const disableBasedOnSurah = surah ? surah.id === 1 && true : true;
+    const disabled = surahPage ? qari.id === 1 && true : disableBasedOnSurah;
+    return disabled;
+  }
+
+  isPlayNextDisabled() {
+    const { surah, qaris, surahPage, qari } = this.props; // eslint-disable-line no-shadow
+    const disableBasedOnSurah = surah ? surah.id === 114 && true : true;
+    const disabled = surahPage
+      ? qari.id === Object.keys(qaris).length
+      : disableBasedOnSurah;
+    console.log(surah, surahPage, disableBasedOnSurah, disabled);
+    return disabled;
+  }
+
+  handleKeyboardEvent(event) {
+    const { code } = event;
+    const { previous, next, playPause, surahs } = this.props; // eslint-disable-line no-shadow
+    if (code === 'Space') {
+      event.preventDefault();
+      playPause();
+    } else if (
+      (code === 'ArrowRight' || code === 'ArrowDown') &&
+      !this.isPlayNextDisabled()
+    ) {
+      event.preventDefault();
+      next({ surahs: Object.values(surahs) });
+    } else if (
+      (code === 'ArrowLeft' || code === 'ArrowUp') &&
+      !this.isPlayPreviousDisabled()
+    ) {
+      event.preventDefault();
+      previous({ surahs: Object.values(surahs) });
     }
   }
 
@@ -89,7 +137,8 @@ class MobilePlayer extends Component {
       return (
         <i
           onClick={playPause}
-          className={`text-primary pointer fa fa-pause-circle ${!file && style.disabled} ${style.playPause}`}
+          className={`text-primary pointer fa fa-pause-circle ${!file &&
+            style.disabled} ${style.playPause}`}
         />
       );
     }
@@ -97,34 +146,33 @@ class MobilePlayer extends Component {
     return (
       <i
         onClick={playPause}
-        className={`text-primary pointer fa fa-play-circle ${!file && style.disabled} ${style.playPause}`}
+        className={`text-primary pointer fa fa-play-circle ${!file &&
+          style.disabled} ${style.playPause}`}
       />
     );
   }
 
   renderPreviousButton() {
-    const { previous, surah, surahs, qaris, surahPage, qari } = this.props; // eslint-disable-line no-shadow
-    const disableBasedOnSurah = surah ? surah.id === 114 && true : true;
-    const disabled = surahPage
-      ? qari.id === Object.keys(qaris).length
-      : disableBasedOnSurah;
+    const { previous, surahs } = this.props; // eslint-disable-line no-shadow
+    const disabled = this.isPlayPreviousDisabled();
 
     return (
       <i
         onClick={() => !disabled && previous({ surahs: Object.values(surahs) })}
-        className={`pointer fa fa-fast-backward fa-lg ${disabled && style.disabled} ${style.previous}`}
+        className={`pointer fa fa-fast-backward fa-lg ${disabled &&
+          style.disabled} ${style.previous}`}
       />
     );
   }
   renderNextButton() {
-    const { next, surah, surahs, surahPage, qari } = this.props; // eslint-disable-line no-shadow
-    const disableBasedOnSurah = surah ? surah.id === 1 && true : true;
-    const disabled = surahPage ? qari.id === 1 && true : disableBasedOnSurah;
+    const { next, surahs } = this.props; // eslint-disable-line no-shadow
+    const disabled = this.isPlayNextDisabled();
 
     return (
       <i
         onClick={() => !disabled && next({ surahs: Object.values(surahs) })}
-        className={`pointer fa fa-fast-forward fa-lg ${disabled && style.disabled} ${style.next}`}
+        className={`pointer fa fa-fast-forward fa-lg ${disabled &&
+          style.disabled} ${style.next}`}
       />
     );
   }
@@ -184,7 +232,7 @@ class MobilePlayer extends Component {
           </h2>
           <h3 className={style.surahName}>{`Surat ${surah.name.simple}`}</h3>
         </div>
-        {open &&
+        {open && (
           <div className={style.controlersContainer}>
             <div className={style.surahMisc}>
               <p> سورة {surah.name.arabic}</p>
@@ -214,7 +262,8 @@ class MobilePlayer extends Component {
                 {this.renderRepeatButton()}
               </div>
             </div>
-          </div>}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/components/Audioplayer/index.js
+++ b/src/components/Audioplayer/index.js
@@ -63,13 +63,62 @@ class Audioplayer extends Component {
     this.handleRemoveFileListeneres = Common.handleRemoveFileListeneres.bind(
       this
     );
+    this.handleKeyboardEvent = this.handleKeyboardEvent.bind(this);
   }
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.handleKeyboardEvent);
+  }
+
   componentWillReceiveProps(nextProps) {
     if (
-      this.props.surah !== nextProps.surah || this.props.qari !== nextProps.qari
+      this.props.surah !== nextProps.surah ||
+      this.props.qari !== nextProps.qari
     ) {
       this.handleFileLoad(nextProps.file);
       this.handleRemoveFileListeneres(this.props.file);
+    }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.handleKeyboardEvent);
+  }
+
+  isPlayPreviousDisabled() {
+    const { surah, surahPage, qari } = this.props; // eslint-disable-line no-shadow
+    const disableBasedOnSurah = surah ? surah.id === 1 && true : true;
+    const disabled = surahPage ? qari.id === 1 && true : disableBasedOnSurah;
+    return disabled;
+  }
+
+  isPlayNextDisabled() {
+    const { surah, qaris, surahPage, qari } = this.props; // eslint-disable-line no-shadow
+    const disableBasedOnSurah = surah ? surah.id === 114 && true : true;
+    const disabled = surahPage
+      ? qari.id === Object.keys(qaris).length
+      : disableBasedOnSurah;
+    console.log(surah, surahPage, disableBasedOnSurah, disabled);
+    return disabled;
+  }
+
+  handleKeyboardEvent(event) {
+    const { code } = event;
+    const { previous, next, playPause, surahs } = this.props; // eslint-disable-line no-shadow
+    if (code === 'Space') {
+      event.preventDefault();
+      playPause();
+    } else if (
+      (code === 'ArrowRight' || code === 'ArrowDown') &&
+      !this.isPlayNextDisabled()
+    ) {
+      event.preventDefault();
+      next({ surahs: Object.values(surahs) });
+    } else if (
+      (code === 'ArrowLeft' || code === 'ArrowUp') &&
+      !this.isPlayPreviousDisabled()
+    ) {
+      event.preventDefault();
+      previous({ surahs: Object.values(surahs) });
     }
   }
 
@@ -83,7 +132,8 @@ class Audioplayer extends Component {
       return (
         <i
           onClick={playPause}
-          className={`text-primary pointer fa fa-pause-circle fa-3x ${!file && styles.disabled}`}
+          className={`text-primary pointer fa fa-pause-circle fa-3x ${!file &&
+            styles.disabled}`}
         />
       );
     }
@@ -91,35 +141,34 @@ class Audioplayer extends Component {
     return (
       <i
         onClick={playPause}
-        className={`text-primary pointer fa fa-play-circle fa-3x ${!file && styles.disabled}`}
+        className={`text-primary pointer fa fa-play-circle fa-3x ${!file &&
+          styles.disabled}`}
       />
     );
   }
 
   renderPreviousButton() {
-    const { previous, surah, surahs, surahPage, qari } = this.props; // eslint-disable-line no-shadow
-    const disableBasedOnSurah = surah ? surah.id === 1 && true : true;
-    const disabled = surahPage ? qari.id === 1 && true : disableBasedOnSurah;
+    const { previous, surahs } = this.props; // eslint-disable-line no-shadow
+    const disabled = this.isPlayPreviousDisabled();
 
     return (
       <i
         onClick={() => !disabled && previous({ surahs: Object.values(surahs) })}
-        className={`pointer fa fa-fast-backward fa-lg ${disabled && styles.disabled}`}
+        className={`pointer fa fa-fast-backward fa-lg ${disabled &&
+          styles.disabled}`}
       />
     );
   }
 
   renderNextButton() {
-    const { next, surah, surahs, qaris, surahPage, qari } = this.props; // eslint-disable-line no-shadow
-    const disableBasedOnSurah = surah ? surah.id === 114 && true : true;
-    const disabled = surahPage
-      ? qari.id === Object.keys(qaris).length
-      : disableBasedOnSurah;
+    const { next, surahs } = this.props; // eslint-disable-line no-shadow
+    const disabled = this.isPlayNextDisabled();
 
     return (
       <i
         onClick={() => !disabled && next({ surahs: Object.values(surahs) })}
-        className={`pointer fa fa-fast-forward fa-lg ${disabled && styles.disabled}`}
+        className={`pointer fa fa-fast-forward fa-lg ${disabled &&
+          styles.disabled}`}
       />
     );
   }
@@ -129,7 +178,8 @@ class Audioplayer extends Component {
 
     return (
       <div
-        className={`text-center pull-right ${styles.toggle} ${shouldRepeat && styles.active}`}
+        className={`text-center pull-right ${styles.toggle} ${shouldRepeat &&
+          styles.active}`}
       >
         <input type="checkbox" id="repeat" className="hidden" />
         <label htmlFor="repeat" className={`pointer`} onClick={repeat}>
@@ -144,7 +194,8 @@ class Audioplayer extends Component {
 
     return (
       <div
-        className={`text-center pull-right ${styles.toggle} ${shouldRandom && styles.active}`}
+        className={`text-center pull-right ${styles.toggle} ${shouldRandom &&
+          styles.active}`}
       >
         <input type="checkbox" id="random" className="hidden" />
         <label htmlFor="repeat" className={`pointer`} onClick={random}>
@@ -181,36 +232,35 @@ class Audioplayer extends Component {
                       </li>
                     ))}
                     <li className={`text-left ${styles.name}`}>
-                      {qari && surah
-                        ? <h4>
-                            {cleanUpBrackets(qari.name)}
-                            <br />
-                            <small className={styles.surahName}>
-                              {surah.name.simple} ({surah.name.english})
-                            </small>
-                          </h4>
-                        : <h4>
-                            --
-                            <br />
-                            <small>
-                              --
-                            </small>
-                          </h4>}
+                      {qari && surah ? (
+                        <h4>
+                          {cleanUpBrackets(qari.name)}
+                          <br />
+                          <small className={styles.surahName}>
+                            {surah.name.simple} ({surah.name.english})
+                          </small>
+                        </h4>
+                      ) : (
+                        <h4>
+                          --
+                          <br />
+                          <small>--</small>
+                        </h4>
+                      )}
                     </li>
                   </ul>
                 </Col>
                 <Col md={6} className={`text-center ${styles.infoContainer}`}>
                   <ul className={`list-inline vertical-align ${styles.info}`}>
                     <li>
-                      {!isNaN(file.duration)
-                        ? <span>
-                            {formatSeconds(file.currentTime)}
-                            {' '}
-                            /
-                            {' '}
-                            {formatSeconds(file.duration)}
-                          </span>
-                        : ''}
+                      {!isNaN(file.duration) ? (
+                        <span>
+                          {formatSeconds(file.currentTime)} /{' '}
+                          {formatSeconds(file.duration)}
+                        </span>
+                      ) : (
+                        ''
+                      )}
                     </li>
                     <li>{this.renderRandomButton()}</li>
                     <li>{this.renderRepeatButton()}</li>

--- a/src/components/Audioplayer/index.js
+++ b/src/components/Audioplayer/index.js
@@ -63,7 +63,9 @@ class Audioplayer extends Component {
     this.handleRemoveFileListeneres = Common.handleRemoveFileListeneres.bind(
       this
     );
-    this.handleKeyboardEvent = this.handleKeyboardEvent.bind(this);
+    this.isPlayPreviousDisabled = Common.isPlayPreviousDisabled.bind(this);
+    this.isPlayNextDisabled = Common.isPlayNextDisabled.bind(this);
+    this.handleKeyboardEvent = Common.handleKeyboardEvent.bind(this);
   }
 
   componentDidMount() {
@@ -82,44 +84,6 @@ class Audioplayer extends Component {
 
   componentWillUnmount() {
     document.removeEventListener('keydown', this.handleKeyboardEvent);
-  }
-
-  isPlayPreviousDisabled() {
-    const { surah, surahPage, qari } = this.props; // eslint-disable-line no-shadow
-    const disableBasedOnSurah = surah ? surah.id === 1 && true : true;
-    const disabled = surahPage ? qari.id === 1 && true : disableBasedOnSurah;
-    return disabled;
-  }
-
-  isPlayNextDisabled() {
-    const { surah, qaris, surahPage, qari } = this.props; // eslint-disable-line no-shadow
-    const disableBasedOnSurah = surah ? surah.id === 114 && true : true;
-    const disabled = surahPage
-      ? qari.id === Object.keys(qaris).length
-      : disableBasedOnSurah;
-    console.log(surah, surahPage, disableBasedOnSurah, disabled);
-    return disabled;
-  }
-
-  handleKeyboardEvent(event) {
-    const { code } = event;
-    const { previous, next, playPause, surahs } = this.props; // eslint-disable-line no-shadow
-    if (code === 'Space') {
-      event.preventDefault();
-      playPause();
-    } else if (
-      (code === 'ArrowRight' || code === 'ArrowDown') &&
-      !this.isPlayNextDisabled()
-    ) {
-      event.preventDefault();
-      next({ surahs: Object.values(surahs) });
-    } else if (
-      (code === 'ArrowLeft' || code === 'ArrowUp') &&
-      !this.isPlayPreviousDisabled()
-    ) {
-      event.preventDefault();
-      previous({ surahs: Object.values(surahs) });
-    }
   }
 
   renderPlayStopButtons() {


### PR DESCRIPTION
In both the desktop and mobile audio players added the ability to:
- play/pause using the spacebar
- skip to the next surah using the right or down arrow keys
- skip to the previous surah using the left or up arrow keys

Closes #92.

Also fixed the bug where the mobile audio player previous button would be disabled instead of the next button, and vice versa. Fixes #94.