### PR TITLE
Revert "Use CF cdn for audio delivery"

### DIFF
--- a/api/tasks/addAudioData.js
+++ b/api/tasks/addAudioData.js
@@ -3,10 +3,9 @@ import probe from 'node-ffprobe';
 
 const createData = (files, index) => {
   const file = files[index];
-  const baseUrl = 'https://audio.qurancdn.com/quran';
 
   if (file.qari && (!file.format || !file.metadata)) {
-    const url = `${baseUrl}/${file.qari.relative_path}${file.file_name}`;
+    const url = `https://download.quranicaudio.com/quran/${file.qari.relative_path}${file.file_name}`;
     try {
       return probe(url, (err, data) => {
         file.metadata = data.metadata;
@@ -24,4 +23,3 @@ const createData = (files, index) => {
 models.audioFile.all({ where: {extension: 'mp3', metadata: null, format: null}, include: [models.qari] }).then(files => {
   return createData(files, 0);
 });
-

--- a/src/actions/audioplayer.js
+++ b/src/actions/audioplayer.js
@@ -1,4 +1,4 @@
-export const AUDIO_URL = 'https://audio.qurancdn.com/quran';
+export const AUDIO_URL = 'https://download.quranicaudio.com/quran';
 export const LOAD = '@@quran/audioplayer/LOAD';
 export const UPDATE = '@@quran/audioplayer/UPDATE';
 export const SET_USER_AGENT = '@@quran/audioplayer/SET_USER_AGENT';

--- a/src/components/SurahList/index.js
+++ b/src/components/SurahList/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import AUDIO_URL from '../../actions/audioplayer';
 import zeroPad from 'utils/zeroPad';
 import Track from 'components/Audioplayer/Track';
 import LinkContainer from 'utils/LinkContainer';
@@ -84,7 +83,7 @@ export default ({
                   <Button
                     color="inverted"
                     className={styles.options}
-                    href={`${AUDIO_URL}/${qari.relativePath}${zeroPad(surah.id, 3)}.mp3`}
+                    href={`http://download.quranicaudio.com/quran/${qari.relativePath}${zeroPad(surah.id, 3)}.mp3`}
                     target="_blank"
                     onClick={event => event.stopPropagation()}
                   >

--- a/src/containers/Main/download.js
+++ b/src/containers/Main/download.js
@@ -1,7 +1,5 @@
 import React, { PropTypes, Component } from 'react';
 import Header from '../../components/Header';
-import AUDIO_URL from '../../actions/audioplayer';
-
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-connect';
 import { load } from 'actions/download';
@@ -30,7 +28,7 @@ class Download extends Component {
                 </h1>
                 <a
                   className={styles.downloadLink}
-                  href={`${AUDIO_URL}/${qaris[qariId].relativePath}${zeroPad(surahId, 3)}.mp3`}
+                  href={`http://download.quranicaudio.com/quran/${qaris[qariId].relativePath}${zeroPad(surahId, 3)}.mp3`}
                 >
                   Download
                 </a>

--- a/src/containers/Qari/Sura.js
+++ b/src/containers/Qari/Sura.js
@@ -10,7 +10,6 @@ import { load as loadFiles } from 'actions/files';
 import Button from 'quran-components/lib/Button';
 import zeroPad from 'utils/zeroPad';
 import Link from 'react-router/lib/Link';
-import AUDIO_URL from '../../actions/audioplayer';
 
 const styles = require('./style.scss');
 
@@ -105,7 +104,7 @@ class Sura extends Component {
                           >
                             <Button
                               className={styles.options}
-                              href={`${AUDIO_URL}/${qari.relativePath}${zeroPad(surah.id, 3)}.mp3`}
+                              href={`https://download.quranicaudio.com/quran/${qari.relativePath}${zeroPad(surah.id, 3)}.mp3`}
                               target="_blank"
                               onClick={event => event.stopPropagation()}
                             >


### PR DESCRIPTION
Reverts quran/audio.quran.com#110

QuranicAudio uses TBs of bandwidth every day, lets first test CloudFlare for Quran.com. 

Reverting this PR.